### PR TITLE
Fixed six>=1.9 issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pyquery
 jira
 IPython
 filemagic
+six>=1.9


### PR DESCRIPTION
I got the below error when running the container.

pkg_resources.ContextualVersionConflict: (six 1.8.0 (/usr/lib/python3/dist-packages), Requirement.parse('six>=1.9'), {'mock'})

added six>=1.9 fixed it
