### PR TITLE
Allow empty CHATROOM_PRESENCE

### DIFF
--- a/config.py
+++ b/config.py
@@ -189,7 +189,7 @@ BOT_ADMINS = tuple(
 CHATROOM_PRESENCE = tuple(
     os.environ.get('CHATROOM_PRESENCE',
                    'err@conference.localhost').split(','),
-)
+) if os.environ.get('CHATROOM_PRESENCE') != '' else tuple()
 # The FullName, or nickname, your bot should use. What you set here will
 # be the nickname that Err shows in chatrooms. Note that some XMPP
 # implementations, notably HipChat, are very picky about what name you


### PR DESCRIPTION
Avoids issues with Slack backend with bot users. With this you'll be able to set an empty variable, otherwise it still can use the default `err@conference.localhost`.

```yapsy_loaded_plugin_Slack_0.SlackAPIResponseError: Slack API call to channels.join failed: user_is_bot```