### PR TITLE
Set the sleekxmpp version to 1.3.1, to avoid certificate bug in 1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Below is the complete list of available options that can be used to customize yo
 - **HIDE_RESTRICTED_ACCESS**: Do not reply error message. Defaults to `False`.
 - **DIVERT_TO_PRIVATE**: Private commands.
 - **MESSAGE_SIZE_LIMIT**: Maximum length a single message may be. Defaults to `10000`.
+- **BOT_EXTRA_PLUGIN_DIR**: Directory to load extra plugins from
 
 # Persistence
 

--- a/config.py
+++ b/config.py
@@ -53,7 +53,7 @@ BOT_DATA_DIR = '/srv/data'
 # locally before publishing it. Note that you can specify only a single
 # directory, however you are free to create subdirectories with multiple
 # plugins inside this directory.
-BOT_EXTRA_PLUGIN_DIR = '/srv/plugins'
+BOT_EXTRA_PLUGIN_DIR = os.environ.get('BOT_EXTRA_PLUGIN_DIR', '/srv/plugins')
 
 # If you use an external backend as a plugin,
 # this is where you tell err where to find it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 errbot
-sleekxmpp
+sleekxmpp==1.3.1
 pyasn1-modules
 irc
 hypchat


### PR DESCRIPTION
The Hipchat backend can't be used with version 1.3.3 of sleekxmpp, see https://github.com/errbotio/errbot/issues/1101 and https://github.com/fritzy/SleekXMPP/issues/462
