### PR TITLE
Fix passing arguments to Errbot in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,7 @@ COPY run.sh /app/venv/bin/run.sh
 
 RUN mkdir /srv/data /srv/plugins /srv/errbackends && chown -R $ERR_USER: /srv /app
 
-
 EXPOSE 3141 3142
 VOLUME ["/srv"]
 
-CMD ["/app/venv/bin/run.sh"]
+ENTRYPOINT ["/app/venv/bin/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ readonly ERRUSER="err"
 
 
 for i in data plugins errbackends; do
-  [[ ! -d "${ERRRUN}/${i}" ]] && mkdir "${ERRRUN}/${i}" 
+  [[ ! -d "${ERRRUN}/${i}" ]] && mkdir "${ERRRUN}/${i}"
 done
 
 [[ -z ${ERRCONF} ]] && [[ ! -e "${ERRRUN}/config.py" ]] && cp /app/config.py ${ERRRUN}
@@ -23,4 +23,4 @@ echo source /app/venv/bin/activate >/srv/.bash_profile
 
 ( for i in $(printenv | grep -v root | grep -v -E '\s+'); do  key=$(echo $i | sed 's/=.*//g'); val=$(echo $i | sed 's/.*=\(.*\)/\1/g'); echo "export $key='$val'"; done )>>/srv/.bash_profile
 # copy default container image config file if not exist on volume but is specified
-su - ${ERRUSER} -c "${ERRBIN} $@"
+su - ${ERRUSER} -c "${ERRBIN} $*"


### PR DESCRIPTION
Hi @rroemhild . First of all, thanks for the Docker image with Errbot. It is really helpful to get started.

I would like to pass custom Errbot config with additional setting for some plugins, but found that an example from README doesn't work:
```console
$ docker run -it -v ~/work/git/errbot-slack:/srv rroemhild/errbot -c /srv/my_config.py
docker: Error response from daemon: oci runtime error: container_linux.go:247:
starting container process caused "exec: \"-c\": executable file not found in $PATH".
```

This PR sets `run.sh` script as an entrypoint and makes expansion of command line arguments to work correctly.