### PR TITLE
Make `CHATROOM_PRESENCE` env variable optional

### DIFF
--- a/config.py
+++ b/config.py
@@ -186,10 +186,9 @@ BOT_ADMINS = tuple(
 # should include the # sign here. For XMPP rooms that are password
 # protected, you can specify another tuple here instead of a string,
 # using the format (RoomName, Password).
-CHATROOM_PRESENCE = tuple(
-    os.environ.get('CHATROOM_PRESENCE',
-                   'err@conference.localhost').split(','),
-) if os.environ.get('CHATROOM_PRESENCE') != '' else tuple()
+CHATROOM_PRESENCE = tuple(os.environ['CHATROOM_PRESENCE'].split(',')
+                          if os.environ.get('CHATROOM_PRESENCE') else [])
+
 # The FullName, or nickname, your bot should use. What you set here will
 # be the nickname that Err shows in chatrooms. Note that some XMPP
 # implementations, notably HipChat, are very picky about what name you


### PR DESCRIPTION
Hi @rroemhild 

This PR makes exporting `CHATROOM_PRESENCE` environmental variable unnecessary.
Previously, if the variable wasn't set (at least to `''` empty string), it would evaluate to `err@conference.localhost` by default, which breaks other Errbot backends.

There should be no regression for XMPP, since it is optional Errbot setting and here we have `docker-compose.yml` file with that variable already has been set. Setting `CHATROOM_PRESENCE` to `""` still works as before.