### PR TITLE
Allow specifying a whitelist of the core plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Below is the complete list of available options that can be used to customize yo
 - **HIDE_RESTRICTED_ACCESS**: Do not reply error message. Defaults to `False`.
 - **DIVERT_TO_PRIVATE**: Private commands.
 - **MESSAGE_SIZE_LIMIT**: Maximum length a single message may be. Defaults to `10000`.
-- **BOT_EXTRA_PLUGIN_DIR**: Directory to load extra plugins from
+- **BOT_EXTRA_PLUGIN_DIR**: Directory to load extra plugins from. Defaults to `/srv/plugins`.
+- **CORE_PLUGINS**: comma-separated subset of the core plugins to load. Defaults to all plugins which are bundled with Errbot.
 
 # Persistence
 

--- a/config.py
+++ b/config.py
@@ -59,6 +59,13 @@ BOT_EXTRA_PLUGIN_DIR = os.environ.get('BOT_EXTRA_PLUGIN_DIR', '/srv/plugins')
 # this is where you tell err where to find it.
 BOT_EXTRA_BACKEND_DIR = '/srv/errbackends'
 
+# If you want only a subset of the core plugins that are bundled with errbot, you can specify them here.
+# CORE_PLUGINS = None # This is default, all core plugins.
+# For example CORE_PLUGINS = ('ACLs', 'Backup', 'Help') you get those names from the .plug files Name entry.
+# For absolutely no plug: CORE_PLUGINS = ()
+CORE_PLUGINS = tuple(os.environ['CORE_PLUGINS'].split(',')) \
+    if os.environ.get('CORE_PLUGINS') else None
+
 # Should plugin dependencies be installed automatically? If this is true
 # then Err will use pip to install any missing dependencies automatically.
 #


### PR DESCRIPTION
Hi @rroemhild 

Some time ago the `CORE_PLUGINS` configuration option was introduced to Errbot. It allows to specify which core plugins to load. I thought it would be useful to expose this feature to the container via an environment variable similar to other configuration options.