### PR TITLE
Move to Debian stable for a newer python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Errbot - the pluggable chatbot
 
-FROM debian:stretch-slim
+FROM debian:stable-slim
 
 MAINTAINER Rafael Römhild <rafael@roemhild.de>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-errbot==5.2
+errbot
 sleekxmpp==1.3.1
 pyasn1-modules
 irc


### PR DESCRIPTION
This PR will bump the used docker image to debian stable which will install a more recent python package by default. It also bumps the errbot package to the latest version. I've tested the docker image by building and running the bot using docker.